### PR TITLE
Updated views, added fields to Event/Project

### DIFF
--- a/app/models/event.server.model.js
+++ b/app/models/event.server.model.js
@@ -27,6 +27,16 @@ var EventSchema = new Schema({
 		required: 'Please include Event date',
 		trim: true
 	},
+    time: {
+        type: String,
+        required: 'Please include a start time',
+        trim: true
+    },
+    location: {
+        type: String,
+        required: 'Please include a location',
+        trim: true
+    },
 	project: {
 		type: mongoose.Schema.Types.ObjectId,
 		ref: 'Project'

--- a/app/tests/event.server.model.test.js
+++ b/app/tests/event.server.model.test.js
@@ -31,6 +31,8 @@ describe('Event Model Unit Tests:', function() {
 				name: 'Event Name',
 				description: 'this is a test description',
 				date: new Date(),
+                time: '10:00 AM',
+                location: 'this is a test location',
 				user: user
 			});
 

--- a/public/modules/core/css/core.css
+++ b/public/modules/core/css/core.css
@@ -54,3 +54,13 @@
     display: inline-table;
     width: 100%;
 }
+
+.event-date {
+    color: #ffffff;
+    font-size: 20px;
+}
+
+.event-location {
+    color: #008080;
+    font-size: 18px;
+}

--- a/public/modules/core/views/home.client.view.html
+++ b/public/modules/core/views/home.client.view.html
@@ -5,14 +5,48 @@
       <div class="col-sm-4">
         <div class="newsfeed">
             <a href="#!/posts"><u class="section-heading">News Feed</u></a>
-            <p>Post #1</p>    
+            <section data-ng-controller="PostsController" data-ng-init="find()">
+    <div class="list-group">
+        <a data-ng-repeat="post in posts" data-ng-href="#!/posts/{{post._id}}" class="list-group-item">
+			<small class="list-group-item-text">
+				Posted on
+				<span data-ng-bind="post.created | date:'medium'"></span>
+				by
+				<span data-ng-bind="post.user.firstName"></span> <span data-ng-bind="post.user.lastName"></span>
+			</small>
+			<h5 class="list-group-item-heading" data-ng-bind="post.name"></h5>
+        </a>
+    </div>
+    <div class="alert alert-warning text-center" data-ng-hide="!posts.$resolved || posts.length">
+    	No Posts yet, why don't you <a href="/#!/posts/create">create one</a>?
+    </div>
+</section>
+  
         </div>
                     
       </div>
       <div class="col-sm-8">
           <div class="eventslist">
               <a href="#!/events"><u class="section-heading">Events List</u></a>
-              <p>Event #1</p>
+              <section data-ng-controller="EventsController" data-ng-init="find()">
+        <div class="list-group">
+        <a data-ng-repeat="event in events | orderBy:'date'" data-ng-href="#!/events/{{event._id}}" class="list-group-item">
+			<h4 class="list-group-item-heading" data-ng-bind="event.name"></h4>
+            <small class="list-group-item-text">
+				Starts at 
+				<span data-ng-bind="event.time"></span>
+				on
+				<span data-ng-bind="event.date | date: 'shortDate'"></span>
+                at
+                <span data-ng-bind="event.location"></span>
+			</small>
+			
+        </a>
+    </div>
+    <div class="alert alert-warning text-center" data-ng-hide="!events.$resolved || events.length">
+    	No Events yet, why don't you <a class="alert-warning" href="/#!/events/create">create one</a>?
+    </div>
+</section>
           </div>   
       </div>
     </div>

--- a/public/modules/events/controllers/events.client.controller.js
+++ b/public/modules/events/controllers/events.client.controller.js
@@ -9,9 +9,11 @@ angular.module('events').controller('EventsController', ['$scope', '$stateParams
 		$scope.create = function() {
 			// Create new Event object
 			var event = new Events ({
-				name: this.name,
-                description: this.description,
-                date: this.date
+				name:           this.name,
+                description:    this.description,
+                date:           this.date,
+                time:           this.time,
+                location:       this.location
 			});
 
 			// Redirect after save
@@ -22,6 +24,8 @@ angular.module('events').controller('EventsController', ['$scope', '$stateParams
 				$scope.name = '';
                 $scope.description = '';
                 $scope.date = '';
+                $scope.time = '';
+                $scope.location = '';
 			}, function(errorResponse) {
 				$scope.error = errorResponse.data.message;
 			});

--- a/public/modules/events/views/create-event.client.view.html
+++ b/public/modules/events/views/create-event.client.view.html
@@ -16,7 +16,15 @@
                     </div>
                     <label class="control-label" for="name">Date</label>
                     <div class="controls">
-                        <input type="date" data-ng-model="date" id="date" class="form-control" placeholder="Date" required>
+                        <input type="date" data-ng-model="date" id="date" class="form-control" placeholder="MM/DD/YYYY" required>
+                    </div>
+                    <label class="control-label" for="name">Time</label>
+                    <div class="controls">
+                        <input type="text" data-ng-model="time" id="date" class="form-control" placeholder="HH:MM AM/PM" required>
+                    </div>
+                    <label class="control-label" for="name">Location</label>
+                    <div class="controls">
+                        <input type="text" data-ng-model="location" id="location" class="form-control" placeholder="Location" required>
                     </div>
 
                 </div>

--- a/public/modules/events/views/edit-event.client.view.html
+++ b/public/modules/events/views/edit-event.client.view.html
@@ -16,7 +16,15 @@
                     </div>
                     <label class="control-label" for="name">Date</label>
                     <div class="controls">
-                        <input type="date" data-ng-model="date" id="date" class="form-control" placeholder="Date" required>
+                        <input type="date" data-ng-model="date" id="date" class="form-control" placeholder="MM/DD/YYYY" required>
+                    </div>
+                    <label class="control-label" for="name">Time</label>
+                    <div class="controls">
+                        <input type="text" data-ng-model="time" id="date" class="form-control" placeholder="HH:MM AM/PM" required>
+                    </div>
+                    <label class="control-label" for="name">Location</label>
+                    <div class="controls">
+                        <input type="text" data-ng-model="location" id="location" class="form-control" placeholder="Location" required>
                     </div>
 
                 </div>

--- a/public/modules/events/views/list-events.client.view.html
+++ b/public/modules/events/views/list-events.client.view.html
@@ -3,14 +3,17 @@
         <h1>Events</h1>
     </div>
     <div class="list-group">
-        <a data-ng-repeat="event in events" data-ng-href="#!/events/{{event._id}}" class="list-group-item">
-			<small class="list-group-item-text">
-				Posted on
-				<span data-ng-bind="event.created | date:'medium'"></span>
-				by
-				<span data-ng-bind="event.user.firstName"></span> <span data-ng-bind="event.user.lastName"></span>
-			</small>
+        <a data-ng-repeat="event in events | orderBy:'date'" data-ng-href="#!/events/{{event._id}}" class="list-group-item">
 			<h4 class="list-group-item-heading" data-ng-bind="event.name"></h4>
+            <small class="list-group-item-text">
+				Starts at 
+				<span data-ng-bind="event.time"></span>
+				on
+				<span data-ng-bind="event.date | date: 'shortDate'"></span>
+                at
+                <span data-ng-bind="event.location"></span>
+			</small>
+			
         </a>
     </div>
     <div class="alert alert-warning text-center" data-ng-hide="!events.$resolved || events.length">

--- a/public/modules/events/views/view-event.client.view.html
+++ b/public/modules/events/views/view-event.client.view.html
@@ -1,7 +1,13 @@
 <section data-ng-controller="EventsController" data-ng-init="findOne()">
 	<div class="page-header">
-		<h1 data-ng-bind="event.name"></h1>
+		<div class="col-sm-8" style="position: relative; top: 0px">
+        <h3 data-ng-bind="event.name"></h3>
+        </div>
+        <span class="event-date" data-ng-bind="event.time"> </span> <b>&middot;</b> <span class="event-date" data-ng-bind="event.date | date:'longDate'"> </span> 
+        <div class="event-location" data-ng-bind="event.location"></div>
 	</div>
+    <p class="" data-ng-bind="event.description"></p>
+    
 	<div class="pull-right" data-ng-show="authentication.user._id == event.user._id">
 		<a class="btn btn-primary" href="/#!/events/{{event._id}}/edit">
 			<i class="glyphicon glyphicon-edit"></i>

--- a/public/modules/projects/controllers/projects.client.controller.js
+++ b/public/modules/projects/controllers/projects.client.controller.js
@@ -9,7 +9,8 @@ angular.module('projects').controller('ProjectsController', ['$scope', '$statePa
 		$scope.create = function() {
 			// Create new Project object
 			var project = new Projects ({
-				name: this.name
+				name: this.name,
+                description: this.description
 			});
 
 			// Redirect after save
@@ -18,6 +19,7 @@ angular.module('projects').controller('ProjectsController', ['$scope', '$statePa
 
 				// Clear form fields
 				$scope.name = '';
+                $scope.description = '';
 			}, function(errorResponse) {
 				$scope.error = errorResponse.data.message;
 			});

--- a/public/modules/projects/views/create-project.client.view.html
+++ b/public/modules/projects/views/create-project.client.view.html
@@ -12,6 +12,12 @@
                     </div>
                 </div>
                 <div class="form-group">
+                    <label class="control-label" for="name">Description</label>
+                    <div class="controls">
+                        <textarea data-ng-model="description" id="name" class="form-control col-md-5" placeholder="Project Description" required></textarea>
+                    </div>
+                </div>
+                <div class="form-group">
                     <input type="submit" class="btn btn-default">
                 </div>
 				<div data-ng-show="error" class="text-danger">

--- a/public/modules/projects/views/view-project.client.view.html
+++ b/public/modules/projects/views/view-project.client.view.html
@@ -2,6 +2,7 @@
 	<div class="page-header">
 		<h1 data-ng-bind="project.name"></h1>
 	</div>
+    <p class="" data-ng-bind="project.description"></p>
 	<div class="pull-right" data-ng-show="authentication.user._id == project.user._id">
 		<a class="btn btn-primary" href="/#!/projects/{{project._id}}/edit">
 			<i class="glyphicon glyphicon-edit"></i>
@@ -10,12 +11,11 @@
 			<i class="glyphicon glyphicon-trash"></i>
 		</a>
 	</div>
+    
 	<small>
 		<em class="text-muted">
-			Posted on
-			<span data-ng-bind="project.created | date:'mediumDate'"></span>
-			by
-			<span data-ng-bind="project.user.firstName"></span> <span data-ng-bind="project.user.lastName"></span>
+			Launched on
+			<span data-ng-bind="project.created | date:'longDate'"></span>
 		</em>
 	</small>
 </section>


### PR DESCRIPTION
-Updated the following views:
Single Event:
![event preview](https://cloud.githubusercontent.com/assets/4752520/4641428/410933de-5437-11e4-85bb-cf54944b877d.PNG)

List of Events (also now sorted in chronological order, soonest at the top):
![list of events in order](https://cloud.githubusercontent.com/assets/4752520/4641433/581cbe88-5437-11e4-9bc7-1aea7bb56769.PNG)

-Added the following fields to "Create" pages (and fixed front-end/back-end references):
Project:
  Description (text)
Event:
  Time (just text for now, should use some sort of time-picker at some point)
  Location (text)

Altered how things are displayed in "List" form (as opposed to "Posted on 10/15/14 by John Barton"):
Events:
  "Starts at 10:00 AM on 10/20/14 at Fletcher Island (UF)"

Home Page Updates:
The Home Page now displays the lists of posts and events (see photo)
![home page wooo](https://cloud.githubusercontent.com/assets/4752520/4641469/c9999b9e-5437-11e4-998a-422f1c87853e.PNG)

This currently shows ALL posts and ALL events, with no way to scroll. This will be fixed in an upcoming release.
